### PR TITLE
Fixed focus angle bug and added redstone support to control board

### DIFF
--- a/common/src/generated/resources/.cache/057e3a48a03f9d4ee4158e6415b6fceb21c87ba3
+++ b/common/src/generated/resources/.cache/057e3a48a03f9d4ee4158e6415b6fceb21c87ba3
@@ -1,6 +1,6 @@
-// 1.20.2	2024-07-20T13:12:19.1864232	Block States: theatrical
+// 1.20.2	2025-12-29T18:15:39.2967938	Block States: theatrical
 80cf9e35e8b8fffe5da0b45777ab6c39c15c3533 assets/theatrical/blockstates/artnet_interface.json
-23028e0ed9d109f6b753e8711b1d16642a1c0b55 assets/theatrical/blockstates/basic_lighting_desk.json
+5a36ae21f6ca9ba6a9411f7b3ab444ecf43a9c8a assets/theatrical/blockstates/basic_lighting_desk.json
 2b77646a280f9864671a9d80a1e992e50b713946 assets/theatrical/blockstates/redstone_interface.json
 761af2b928f16739c5b198b1310007e9284b3603 assets/theatrical/blockstates/tank_trap.json
 be395e721add9d37a0ee65988b72ae8680a37307 assets/theatrical/blockstates/truss.json

--- a/common/src/generated/resources/assets/theatrical/blockstates/basic_lighting_desk.json
+++ b/common/src/generated/resources/assets/theatrical/blockstates/basic_lighting_desk.json
@@ -1,17 +1,32 @@
 {
   "variants": {
-    "facing=east": {
+    "facing=east,triggered=false": {
       "model": "theatrical:block/lighting_console",
       "y": 90
     },
-    "facing=north": {
+    "facing=east,triggered=true": {
+      "model": "theatrical:block/lighting_console",
+      "y": 90
+    },
+    "facing=north,triggered=false": {
       "model": "theatrical:block/lighting_console"
     },
-    "facing=south": {
+    "facing=north,triggered=true": {
+      "model": "theatrical:block/lighting_console"
+    },
+    "facing=south,triggered=false": {
       "model": "theatrical:block/lighting_console",
       "y": 180
     },
-    "facing=west": {
+    "facing=south,triggered=true": {
+      "model": "theatrical:block/lighting_console",
+      "y": 180
+    },
+    "facing=west,triggered=false": {
+      "model": "theatrical:block/lighting_console",
+      "y": 270
+    },
+    "facing=west,triggered=true": {
       "model": "theatrical:block/lighting_console",
       "y": 270
     }

--- a/common/src/main/java/dev/imabad/theatrical/blocks/control/BasicLightingDeskBlock.java
+++ b/common/src/main/java/dev/imabad/theatrical/blocks/control/BasicLightingDeskBlock.java
@@ -26,6 +26,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.phys.BlockHitResult;
@@ -38,6 +39,8 @@ public class BasicLightingDeskBlock extends Block implements EntityBlock {
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
     private static final VoxelShape SHAPE = Shapes.create(0, 0, 0, 16 / 16D, 3 / 16D, 16 / 16D);
 
+    public static final BooleanProperty LIT = BlockStateProperties.LIT;
+
     public BasicLightingDeskBlock() {
         super(Properties.of()
                 .requiresCorrectToolForDrops()
@@ -46,18 +49,20 @@ public class BasicLightingDeskBlock extends Block implements EntityBlock {
                 .isValidSpawn(Blocks::neverAllowSpawn)
                 .mapColor(MapColor.METAL)
                 .sound(SoundType.METAL));
-        this.registerDefaultState(this.getStateDefinition().any().setValue(FACING, Direction.NORTH));
+
+        this.registerDefaultState(this.getStateDefinition().any().setValue(FACING, Direction.NORTH).setValue(LIT, false));
     }
 
     @Nullable
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
-        return this.defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite());
+        return this.defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite()).setValue(LIT, context.getLevel().hasNeighborSignal(context.getClickedPos()));
     }
 
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(FACING);
+        builder.add(LIT);
     }
 
 
@@ -107,4 +112,19 @@ public class BasicLightingDeskBlock extends Block implements EntityBlock {
         }
         return InteractionResult.SUCCESS;
     }
+    public void neighborChanged(BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos neighborPos, boolean movedByPiston) {
+        if (!level.isClientSide) {
+            boolean powered=level.hasNeighborSignal(pos);
+            BasicLightingDeskBlockEntity be = (BasicLightingDeskBlockEntity) level.getBlockEntity(pos);
+            if(powered && !state.getValue(LIT)){
+                if(be.isRunMode()){
+                    be.clickButton();
+                }
+                level.setBlock(pos, state.setValue(LIT, true), 3);
+            }else if(!powered && state.getValue(LIT)){
+                level.setBlock(pos, state.setValue(LIT, false), 3);
+            }
+        }
+    }
+
 }

--- a/common/src/main/java/dev/imabad/theatrical/blocks/control/BasicLightingDeskBlock.java
+++ b/common/src/main/java/dev/imabad/theatrical/blocks/control/BasicLightingDeskBlock.java
@@ -39,7 +39,7 @@ public class BasicLightingDeskBlock extends Block implements EntityBlock {
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
     private static final VoxelShape SHAPE = Shapes.create(0, 0, 0, 16 / 16D, 3 / 16D, 16 / 16D);
 
-    public static final BooleanProperty LIT = BlockStateProperties.LIT;
+    public static final BooleanProperty TRIGGERED = BooleanProperty.create("triggered");
 
     public BasicLightingDeskBlock() {
         super(Properties.of()
@@ -50,19 +50,19 @@ public class BasicLightingDeskBlock extends Block implements EntityBlock {
                 .mapColor(MapColor.METAL)
                 .sound(SoundType.METAL));
 
-        this.registerDefaultState(this.getStateDefinition().any().setValue(FACING, Direction.NORTH).setValue(LIT, false));
+        this.registerDefaultState(this.getStateDefinition().any().setValue(FACING, Direction.NORTH).setValue(TRIGGERED, false));
     }
 
     @Nullable
     @Override
     public BlockState getStateForPlacement(BlockPlaceContext context) {
-        return this.defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite()).setValue(LIT, context.getLevel().hasNeighborSignal(context.getClickedPos()));
+        return this.defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite()).setValue(TRIGGERED, context.getLevel().hasNeighborSignal(context.getClickedPos()));
     }
 
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(FACING);
-        builder.add(LIT);
+        builder.add(TRIGGERED);
     }
 
 
@@ -71,11 +71,6 @@ public class BasicLightingDeskBlock extends Block implements EntityBlock {
     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
         return new BasicLightingDeskBlockEntity(pos, state);
     }
-
-//    @Override
-//    public RenderShape getRenderShape(BlockState blockState) {
-//        return RenderShape.ENTITYBLOCK_ANIMATED;
-//    }
 
     @Override
     public float getShadeBrightness(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos) {
@@ -115,15 +110,17 @@ public class BasicLightingDeskBlock extends Block implements EntityBlock {
     public void neighborChanged(BlockState state, Level level, BlockPos pos, Block neighborBlock, BlockPos neighborPos, boolean movedByPiston) {
         if (!level.isClientSide) {
             boolean powered=level.hasNeighborSignal(pos);
-            BasicLightingDeskBlockEntity be = (BasicLightingDeskBlockEntity) level.getBlockEntity(pos);
-            if(powered && !state.getValue(LIT)){
-                if(be.isRunMode()){
-                    be.clickButton();
+            if(level.getBlockEntity(pos) instanceof BasicLightingDeskBlockEntity be){
+                if(powered && !state.getValue(TRIGGERED)){
+                    if(be.isRunMode()){
+                        be.clickButton();
+                    }
+                    level.setBlock(pos, state.setValue(TRIGGERED, true), 3);
+                }else if(!powered && state.getValue(TRIGGERED)){
+                    level.setBlock(pos, state.setValue(TRIGGERED, false), 3);
                 }
-                level.setBlock(pos, state.setValue(LIT, true), 3);
-            }else if(!powered && state.getValue(LIT)){
-                level.setBlock(pos, state.setValue(LIT, false), 3);
             }
+
         }
     }
 

--- a/common/src/main/java/dev/imabad/theatrical/client/blockentities/FixtureRenderer.java
+++ b/common/src/main/java/dev/imabad/theatrical/client/blockentities/FixtureRenderer.java
@@ -88,28 +88,28 @@ public abstract class FixtureRenderer<T extends BaseLightBlockEntity> implements
         Matrix4f m = stack.last().pose();
         Matrix3f normal = stack.last().normal();
         length += 0.5f;
-        float endMultiplier = 1 + tileEntityFixture.getFocus()*length*0.05f;
+        float endMultiplier = 1 + tileEntityFixture.getFocus()*length*0.03f;
 
-        int endalpha = 0;
-        addVertex(builder, m, normal, r, g, b, endalpha, beamSize * endMultiplier, beamSize * endMultiplier, -length);
+
+        addVertex(builder, m, normal, r, g, b, 0, beamSize * endMultiplier, beamSize * endMultiplier, -length);
         addVertex(builder, m, normal, r, g, b, a,  beamSize, beamSize, 0);
         addVertex(builder, m, normal, r, g, b, a, beamSize, -beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, endalpha,beamSize * endMultiplier, -beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, 0,beamSize * endMultiplier, -beamSize * endMultiplier, -length);
 
-        addVertex(builder, m, normal, r, g, b, endalpha, -beamSize * endMultiplier, -beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, 0, -beamSize * endMultiplier, -beamSize * endMultiplier, -length);
         addVertex(builder, m, normal, r, g, b, a, -beamSize, -beamSize, 0);
         addVertex(builder, m, normal, r, g, b, a, -beamSize, beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, endalpha, -beamSize * endMultiplier, beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, 0, -beamSize * endMultiplier, beamSize * endMultiplier, -length);
 
-        addVertex(builder, m, normal, r, g, b, endalpha, -beamSize * endMultiplier, beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, 0, -beamSize * endMultiplier, beamSize * endMultiplier, -length);
         addVertex(builder, m, normal, r, g, b, a, -beamSize, beamSize, 0);
         addVertex(builder, m, normal, r, g, b, a, beamSize, beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, endalpha, beamSize * endMultiplier, beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, 0, beamSize * endMultiplier, beamSize * endMultiplier, -length);
 
-        addVertex(builder, m, normal, r, g, b, endalpha, beamSize * endMultiplier, -beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, 0, beamSize * endMultiplier, -beamSize * endMultiplier, -length);
         addVertex(builder, m, normal, r, g, b, a, beamSize, -beamSize, 0);
         addVertex(builder, m, normal, r, g, b, a, -beamSize, -beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, endalpha, -beamSize * endMultiplier, -beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, 0, -beamSize * endMultiplier, -beamSize * endMultiplier, -length);
 
 
 

--- a/common/src/main/java/dev/imabad/theatrical/client/blockentities/FixtureRenderer.java
+++ b/common/src/main/java/dev/imabad/theatrical/client/blockentities/FixtureRenderer.java
@@ -87,26 +87,32 @@ public abstract class FixtureRenderer<T extends BaseLightBlockEntity> implements
         int a = (int) (alpha * 255);
         Matrix4f m = stack.last().pose();
         Matrix3f normal = stack.last().normal();
-        float endMultiplier = beamSize * tileEntityFixture.getFocus();
-        addVertex(builder, m, normal, r, g, b, 0, beamSize * endMultiplier, beamSize * endMultiplier, -length);
+        length += 0.5f;
+        float endMultiplier = 1 + tileEntityFixture.getFocus()*length*0.05f;
+
+        int endalpha = 0;
+        addVertex(builder, m, normal, r, g, b, endalpha, beamSize * endMultiplier, beamSize * endMultiplier, -length);
         addVertex(builder, m, normal, r, g, b, a,  beamSize, beamSize, 0);
         addVertex(builder, m, normal, r, g, b, a, beamSize, -beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, 0,beamSize * endMultiplier, -beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, endalpha,beamSize * endMultiplier, -beamSize * endMultiplier, -length);
 
-        addVertex(builder, m, normal, r, g, b, 0, -beamSize * endMultiplier, -beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, endalpha, -beamSize * endMultiplier, -beamSize * endMultiplier, -length);
         addVertex(builder, m, normal, r, g, b, a, -beamSize, -beamSize, 0);
         addVertex(builder, m, normal, r, g, b, a, -beamSize, beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, 0, -beamSize * endMultiplier, beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, endalpha, -beamSize * endMultiplier, beamSize * endMultiplier, -length);
 
-        addVertex(builder, m, normal, r, g, b, 0, -beamSize * endMultiplier, beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, endalpha, -beamSize * endMultiplier, beamSize * endMultiplier, -length);
         addVertex(builder, m, normal, r, g, b, a, -beamSize, beamSize, 0);
         addVertex(builder, m, normal, r, g, b, a, beamSize, beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, 0, beamSize * endMultiplier, beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, endalpha, beamSize * endMultiplier, beamSize * endMultiplier, -length);
 
-        addVertex(builder, m, normal, r, g, b, 0, beamSize * endMultiplier, -beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, endalpha, beamSize * endMultiplier, -beamSize * endMultiplier, -length);
         addVertex(builder, m, normal, r, g, b, a, beamSize, -beamSize, 0);
         addVertex(builder, m, normal, r, g, b, a, -beamSize, -beamSize, 0);
-        addVertex(builder, m, normal, r, g, b, 0, -beamSize * endMultiplier, -beamSize * endMultiplier, -length);
+        addVertex(builder, m, normal, r, g, b, endalpha, -beamSize * endMultiplier, -beamSize * endMultiplier, -length);
+
+
+
     }
 
     protected void addVertex(VertexConsumer builder, Matrix4f matrix4f, Matrix3f matrix3f, int r, int g, int b, int a, float x, float y, float z) {


### PR DESCRIPTION
The focus of lights is now scaled based on the length properly, meaning they wont splay out or sharpen drastically when moving between far and near ranges.

Redstone support for the control board just calls "go" if its in run mode when powered