### PR TITLE
fix: enforce server-side validation on DMX network packets

### DIFF
--- a/common/src/main/java/dev/imabad/theatrical/Theatrical.java
+++ b/common/src/main/java/dev/imabad/theatrical/Theatrical.java
@@ -70,7 +70,11 @@ public class Theatrical {
             for (TheatricalNetwork network : instance.getNetworksForPlayer(event.connection.player.getUUID())) {
                 for (Integer universe : network.dmx().getUniverses()) {
                     List<DMXDevice> devices = new ArrayList<>();
-                    network.dmx().getConsumers(universe).forEach(consumer -> {
+                    var consumers = network.dmx().getConsumers(universe);
+                    if (consumers == null) {
+                        continue;
+                    }
+                    consumers.forEach(consumer -> {
                         devices.add(new DMXDevice(consumer.getDeviceId(), consumer.getChannelStart(),
                                 consumer.getChannelCount(), consumer.getDeviceTypeId(), consumer.getActivePersonality(), consumer.getModelName(),
                                 consumer.getFixtureId()));

--- a/common/src/main/java/dev/imabad/theatrical/Theatrical.java
+++ b/common/src/main/java/dev/imabad/theatrical/Theatrical.java
@@ -3,6 +3,8 @@ package dev.imabad.theatrical;
 import dev.architectury.event.events.common.CommandRegistrationEvent;
 import dev.architectury.event.events.common.LifecycleEvent;
 import dev.architectury.event.events.common.PlayerEvent;
+import dev.architectury.event.events.common.TickEvent;
+import dev.imabad.theatrical.networks.ServerDmxBroker;
 import dev.architectury.platform.Platform;
 import dev.architectury.registry.CreativeTabRegistry;
 import dev.architectury.registry.registries.DeferredRegister;
@@ -83,6 +85,7 @@ public class Theatrical {
                 }
             }
         });
+        TickEvent.SERVER_POST.register(server -> ServerDmxBroker.flush(server));
         LifecycleEvent.SERVER_LEVEL_UNLOAD.register(world -> {
             if(world.dimension().equals(Level.OVERWORLD)){
                 TheatricalNetworkData.unloadLevel();

--- a/common/src/main/java/dev/imabad/theatrical/TheatricalClient.java
+++ b/common/src/main/java/dev/imabad/theatrical/TheatricalClient.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
 import dev.architectury.event.events.client.ClientPlayerEvent;
+import dev.architectury.event.events.client.ClientTickEvent;
 import dev.architectury.platform.Platform;
 import dev.architectury.registry.client.rendering.BlockEntityRendererRegistry;
 import dev.imabad.theatrical.api.dmx.DMXConsumer;
@@ -64,6 +65,14 @@ public class TheatricalClient {
         BlockEntityRendererRegistry.register(BlockEntities.LED_PANEL.get(), LEDPanelRenderer::new);
         BlockEntityRendererRegistry.register(BlockEntities.BASIC_LIGHTING_DESK.get(), BasicLightingConsoleRenderer::new);
         artNetManager = new ArtNetManager();
+        ClientTickEvent.CLIENT_LEVEL_POST.register(world -> {
+            if (TheatricalConfig.INSTANCE.CLIENT.artnetEnabled && artNetManager != null) {
+                TheatricalArtNetClient client = artNetManager.getClient();
+                if (client != null) {
+                    client.flushPendingToServer();
+                }
+            }
+        });
         ClientPlayerEvent.CLIENT_PLAYER_JOIN.register((event) -> {
             new RequestNetworks().sendToServer();
             if(TheatricalConfig.INSTANCE.CLIENT.artnetEnabled){

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/interfaces/RedstoneInterfaceBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/interfaces/RedstoneInterfaceBlockEntity.java
@@ -7,6 +7,7 @@ import dev.imabad.theatrical.blockentities.BlockEntities;
 import dev.imabad.theatrical.blockentities.ClientSyncBlockEntity;
 import dev.imabad.theatrical.networks.TheatricalNetworkData;
 import dev.imabad.theatrical.fixtures.Fixtures;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import dev.imabad.theatrical.util.RndUtils;
 import dev.imabad.theatrical.util.UUIDUtil;
 import net.minecraft.core.BlockPos;
@@ -17,7 +18,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
-import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
 
@@ -132,9 +132,7 @@ public class RedstoneInterfaceBlockEntity extends ClientSyncBlockEntity implemen
 
     @Override
     public void consume(byte[] dmxValues) {
-        int start = this.getChannelStart() > 0 ? this.getChannelStart() - 1 : 0;
-        byte[] ourValues = Arrays.copyOfRange(dmxValues, start,
-                start+ this.getChannelCount());
+        byte[] ourValues = DmxPacketGuard.sliceDmxChannels(dmxValues, getChannelStart(), getChannelCount());
         if(ourValues.length < 1){
             return;
         }
@@ -149,6 +147,10 @@ public class RedstoneInterfaceBlockEntity extends ClientSyncBlockEntity implemen
     }
 
     public void setChannelStartPoint(int channelStartPoint) {
+        if (!DmxPacketGuard.isValidAddress(channelStartPoint)
+                || !DmxPacketGuard.fitsInUniverse(channelStartPoint, getChannelCount())) {
+            return;
+        }
         this.channelStartPoint = channelStartPoint;
         this.setChanged();
         updateConsumer();
@@ -157,6 +159,9 @@ public class RedstoneInterfaceBlockEntity extends ClientSyncBlockEntity implemen
 
     public void setUniverse(int universe) {
         if(this.dmxUniverse == universe){
+            return;
+        }
+        if (!DmxPacketGuard.isValidUniverse(universe)) {
             return;
         }
         removeConsumer();

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/BaseDMXConsumerLightBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/BaseDMXConsumerLightBlockEntity.java
@@ -4,6 +4,7 @@ import ch.bildspur.artnet.rdm.RDMDeviceId;
 import dev.imabad.theatrical.Constants;
 import dev.imabad.theatrical.api.dmx.DMXConsumer;
 import dev.imabad.theatrical.networks.TheatricalNetworkData;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import dev.imabad.theatrical.util.RndUtils;
 import dev.imabad.theatrical.util.UUIDUtil;
 import net.minecraft.core.BlockPos;
@@ -94,6 +95,9 @@ public abstract class BaseDMXConsumerLightBlockEntity extends BaseLightBlockEnti
         if(this.dmxUniverse == dmxUniverse){
             return;
         }
+        if (!DmxPacketGuard.isValidUniverse(dmxUniverse)) {
+            return;
+        }
         removeConsumer();
         this.dmxUniverse = dmxUniverse;
         addConsumer();
@@ -107,6 +111,10 @@ public abstract class BaseDMXConsumerLightBlockEntity extends BaseLightBlockEnti
 
     public void setChannelStartPoint(int channelStartPoint) {
         if(this.channelStartPoint == channelStartPoint){
+            return;
+        }
+        if (!DmxPacketGuard.isValidAddress(channelStartPoint)
+                || !DmxPacketGuard.fitsInUniverse(channelStartPoint, channelCount)) {
             return;
         }
         this.channelStartPoint = channelStartPoint;

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/BaseLightBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/BaseLightBlockEntity.java
@@ -451,7 +451,15 @@ public abstract class BaseLightBlockEntity extends ClientSyncBlockEntity impleme
 
     @Override
     public void lightTick() {
-
+        if (level != null && level.isClientSide()) {
+            prevPan = pan;
+            prevTilt = tilt;
+            prevFocus = focus;
+            prevIntensity = intensity;
+            prevRed = red;
+            prevGreen = green;
+            prevBlue = blue;
+        }
     }
 
     @Override

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/BaseLightBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/BaseLightBlockEntity.java
@@ -178,9 +178,23 @@ public abstract class BaseLightBlockEntity extends ClientSyncBlockEntity impleme
         return false;
     }
 
+    /** Un seul sendBlockUpdated par trame DMX (évite le double sync prev + values). */
+    protected void finishDmxConsume(boolean valuesChanged, boolean prevAdvanced) {
+        if (level == null || level.isClientSide()) {
+            return;
+        }
+        if (valuesChanged || prevAdvanced) {
+            level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
+        }
+        if (valuesChanged) {
+            setChanged();
+        }
+    }
+
     public static <T extends BlockEntity> void tick(Level level, BlockPos pos, BlockState state, T be) {
         BaseLightBlockEntity tile = (BaseLightBlockEntity) be;
-        if(tile.shouldTrace()){
+        // Raycast uniquement côté client (lumière dynamique + rendu) — inutile et coûteux sur le serveur.
+        if (level.isClientSide() && tile.shouldTrace()) {
             tile.distance = tile.doRayTrace();
         }
         tile.tick();

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/FresnelBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/FresnelBlockEntity.java
@@ -5,6 +5,7 @@ import dev.imabad.theatrical.api.FocusableFixture;
 import dev.imabad.theatrical.blockentities.BlockEntities;
 import dev.imabad.theatrical.blocks.light.BaseLightBlock;
 import dev.imabad.theatrical.fixtures.Fixtures;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
@@ -12,8 +13,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Arrays;
 
 public class FresnelBlockEntity extends BaseDMXConsumerLightBlockEntity implements FocusableFixture {
 
@@ -59,9 +58,7 @@ public class FresnelBlockEntity extends BaseDMXConsumerLightBlockEntity implemen
 
     @Override
     public void consume(byte[] dmxValues) {
-        int start = this.getChannelStart() > 0 ? this.getChannelStart() - 1 : 0;
-        byte[] ourValues = Arrays.copyOfRange(dmxValues, start,
-                start+ this.getChannelCount());
+        byte[] ourValues = DmxPacketGuard.sliceDmxChannels(dmxValues, getChannelStart(), getChannelCount());
         if(ourValues.length < 4){
             return;
         }

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/FresnelBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/FresnelBlockEntity.java
@@ -10,7 +10,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
@@ -62,9 +61,7 @@ public class FresnelBlockEntity extends BaseDMXConsumerLightBlockEntity implemen
         if(ourValues.length < 4){
             return;
         }
-        if(this.storePrev()){
-            level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
-        }
+        boolean prevAdvanced = this.storePrev();
         boolean hasUpdated = false;
         int newIntensity = convertByteToInt(ourValues[0]);
         if(intensity != newIntensity){
@@ -86,10 +83,7 @@ public class FresnelBlockEntity extends BaseDMXConsumerLightBlockEntity implemen
             blue = newBlue;
             hasUpdated = true;
         }
-        if(hasUpdated) {
-            level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
-            setChanged();
-        }
+        finishDmxConsume(hasUpdated, prevAdvanced);
     }
 
     @Override

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/LEDPanelBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/LEDPanelBlockEntity.java
@@ -3,12 +3,11 @@ package dev.imabad.theatrical.blockentities.light;
 import dev.imabad.theatrical.api.Fixture;
 import dev.imabad.theatrical.blockentities.BlockEntities;
 import dev.imabad.theatrical.fixtures.Fixtures;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-
-import java.util.Arrays;
 
 public class LEDPanelBlockEntity extends BaseDMXConsumerLightBlockEntity {
     public LEDPanelBlockEntity(BlockPos blockPos, BlockState blockState) {
@@ -23,9 +22,7 @@ public class LEDPanelBlockEntity extends BaseDMXConsumerLightBlockEntity {
 
     @Override
     public void consume(byte[] dmxValues) {
-        int start = this.getChannelStart() > 0 ? this.getChannelStart() - 1 : 0;
-        byte[] ourValues = Arrays.copyOfRange(dmxValues, start,
-                start+ this.getChannelCount());
+        byte[] ourValues = DmxPacketGuard.sliceDmxChannels(dmxValues, getChannelStart(), getChannelCount());
         if(ourValues.length < 4){
             return;
         }

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/LEDPanelBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/LEDPanelBlockEntity.java
@@ -6,7 +6,6 @@ import dev.imabad.theatrical.fixtures.Fixtures;
 import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class LEDPanelBlockEntity extends BaseDMXConsumerLightBlockEntity {
@@ -26,9 +25,7 @@ public class LEDPanelBlockEntity extends BaseDMXConsumerLightBlockEntity {
         if(ourValues.length < 4){
             return;
         }
-        if(this.storePrev()){
-            level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
-        }
+        boolean prevAdvanced = this.storePrev();
         boolean hasUpdated = false;
         int newIntensity = convertByteToInt(ourValues[0]);
         if(intensity != newIntensity){
@@ -50,10 +47,7 @@ public class LEDPanelBlockEntity extends BaseDMXConsumerLightBlockEntity {
             blue = newBlue;
             hasUpdated = true;
         }
-        if(hasUpdated) {
-            level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
-            setChanged();
-        }
+        finishDmxConsume(hasUpdated, prevAdvanced);
     }
 
     @Override

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/MovingLightBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/MovingLightBlockEntity.java
@@ -32,9 +32,7 @@ public class MovingLightBlockEntity extends BaseDMXConsumerLightBlockEntity {
         if(ourValues.length < 7){
             return;
         }
-        if(this.storePrev()){
-            level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
-        }
+        boolean prevAdvanced = this.storePrev();
         boolean hasUpdated = false;
         int newIntensity = convertByteToInt(ourValues[0]);
         if(intensity != newIntensity){
@@ -71,10 +69,7 @@ public class MovingLightBlockEntity extends BaseDMXConsumerLightBlockEntity {
             tilt = newTilt;
             hasUpdated = true;
         }
-        if(hasUpdated) {
-            level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
-            setChanged();
-        }
+        finishDmxConsume(hasUpdated, prevAdvanced);
     }
 
     @Override

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/MovingLightBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/MovingLightBlockEntity.java
@@ -4,14 +4,13 @@ import dev.imabad.theatrical.api.Fixture;
 import dev.imabad.theatrical.blockentities.BlockEntities;
 import dev.imabad.theatrical.blocks.light.MovingLightBlock;
 import dev.imabad.theatrical.fixtures.Fixtures;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-
-import java.util.Arrays;
 
 public class MovingLightBlockEntity extends BaseDMXConsumerLightBlockEntity {
     public MovingLightBlockEntity(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
@@ -29,9 +28,7 @@ public class MovingLightBlockEntity extends BaseDMXConsumerLightBlockEntity {
 
     @Override
     public void consume(byte[] dmxValues) {
-        int start = this.getChannelStart() > 0 ? this.getChannelStart() - 1 : 0;
-        byte[] ourValues = Arrays.copyOfRange(dmxValues, start,
-                start+ this.getChannelCount());
+        byte[] ourValues = DmxPacketGuard.sliceDmxChannels(dmxValues, getChannelStart(), getChannelCount());
         if(ourValues.length < 7){
             return;
         }

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/MovingWashBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/MovingWashBlockEntity.java
@@ -4,14 +4,13 @@ import dev.imabad.theatrical.api.Fixture;
 import dev.imabad.theatrical.blockentities.BlockEntities;
 import dev.imabad.theatrical.blocks.light.MovingWashBlock;
 import dev.imabad.theatrical.fixtures.Fixtures;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-
-import java.util.Arrays;
 
 public class MovingWashBlockEntity extends BaseDMXConsumerLightBlockEntity {
     public MovingWashBlockEntity(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
@@ -29,9 +28,7 @@ public class MovingWashBlockEntity extends BaseDMXConsumerLightBlockEntity {
 
     @Override
     public void consume(byte[] dmxValues) {
-        int start = this.getChannelStart() > 0 ? this.getChannelStart() - 1 : 0;
-        byte[] ourValues = Arrays.copyOfRange(dmxValues, start,
-                start+ this.getChannelCount());
+        byte[] ourValues = DmxPacketGuard.sliceDmxChannels(dmxValues, getChannelStart(), getChannelCount());
         if(ourValues.length < 7){
             return;
         }

--- a/common/src/main/java/dev/imabad/theatrical/blockentities/light/MovingWashBlockEntity.java
+++ b/common/src/main/java/dev/imabad/theatrical/blockentities/light/MovingWashBlockEntity.java
@@ -32,9 +32,8 @@ public class MovingWashBlockEntity extends BaseDMXConsumerLightBlockEntity {
         if(ourValues.length < 7){
             return;
         }
-        if(this.storePrev()){
-            level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
-        }
+        boolean prevAdvanced = this.storePrev();
+        int _pi = intensity, _pr = red, _pg = green, _pb = blue, _pf = focus, _pp = pan, _pt = tilt;
         intensity = convertByteToInt(ourValues[0]);
         red = convertByteToInt(ourValues[1]);
         green = convertByteToInt(ourValues[2]);
@@ -42,8 +41,9 @@ public class MovingWashBlockEntity extends BaseDMXConsumerLightBlockEntity {
         focus = convertByteToInt(ourValues[4]);
         pan = (int) ((convertByteToInt(ourValues[5]) * 360) / 255f) - 180;
         tilt = (int) ((convertByteToInt(ourValues[6]) * 270) / 255F) - 225;
-        level.sendBlockUpdated(getBlockPos(), getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
-        setChanged();
+        boolean hasUpdated = intensity != _pi || red != _pr || green != _pg || blue != _pb
+                || focus != _pf || pan != _pp || tilt != _pt;
+        finishDmxConsume(hasUpdated, prevAdvanced);
     }
 
     @Override

--- a/common/src/main/java/dev/imabad/theatrical/client/dmx/TheatricalArtNetClient.java
+++ b/common/src/main/java/dev/imabad/theatrical/client/dmx/TheatricalArtNetClient.java
@@ -186,8 +186,8 @@ public class TheatricalArtNetClient extends ArtNetClient {
         if (manager.getNetworkId() == UUIDUtil.NULL || pendingServerFrames.isEmpty()) {
             return;
         }
-        for (IntObjectMap.PrimitiveEntry<byte[]> entry : pendingServerFrames.int2ObjectEntrySet()) {
-            new SendArtNetData(manager.getNetworkId(), entry.intKey(), entry.value()).sendToServer();
+        for (IntObjectMap.Entry<byte[]> entry : pendingServerFrames.entries()) {
+            new SendArtNetData(manager.getNetworkId(), entry.key(), entry.value()).sendToServer();
         }
         pendingServerFrames.clear();
     }

--- a/common/src/main/java/dev/imabad/theatrical/client/dmx/TheatricalArtNetClient.java
+++ b/common/src/main/java/dev/imabad/theatrical/client/dmx/TheatricalArtNetClient.java
@@ -171,6 +171,7 @@ public class TheatricalArtNetClient extends ArtNetClient {
         return (int) (sum * (sum + 1) / 2) + a;
     }
 
+    private final Object pendingServerLock = new Object();
     private final Map<Integer, byte[]> pendingServerFrames = new HashMap<>();
 
     public void queueServerFrame(int networkUniverse, byte[] dmxData) {
@@ -178,18 +179,27 @@ public class TheatricalArtNetClient extends ArtNetClient {
             return;
         }
         int length = Math.min(dmxData.length, 512);
-        pendingServerFrames.put(networkUniverse, Arrays.copyOf(dmxData, length));
+        synchronized (pendingServerLock) {
+            pendingServerFrames.put(networkUniverse, Arrays.copyOf(dmxData, length));
+        }
     }
 
     /** Envoie au serveur au plus une trame par univers et par tick client. */
     public void flushPendingToServer() {
-        if (manager.getNetworkId() == UUIDUtil.NULL || pendingServerFrames.isEmpty()) {
+        if (manager.getNetworkId() == UUIDUtil.NULL) {
             return;
         }
-        for (Map.Entry<Integer, byte[]> entry : pendingServerFrames.entrySet()) {
+        Map<Integer, byte[]> toSend;
+        synchronized (pendingServerLock) {
+            if (pendingServerFrames.isEmpty()) {
+                return;
+            }
+            toSend = new HashMap<>(pendingServerFrames);
+            pendingServerFrames.clear();
+        }
+        for (Map.Entry<Integer, byte[]> entry : toSend.entrySet()) {
             new SendArtNetData(manager.getNetworkId(), entry.getKey(), entry.getValue()).sendToServer();
         }
-        pendingServerFrames.clear();
     }
 
     private void onPacketReceived(InetAddress sourceAddress, final ArtNetPacket packet) {

--- a/common/src/main/java/dev/imabad/theatrical/client/dmx/TheatricalArtNetClient.java
+++ b/common/src/main/java/dev/imabad/theatrical/client/dmx/TheatricalArtNetClient.java
@@ -171,6 +171,27 @@ public class TheatricalArtNetClient extends ArtNetClient {
         return (int) (sum * (sum + 1) / 2) + a;
     }
 
+    private final IntObjectMap<byte[]> pendingServerFrames = new IntObjectHashMap<>();
+
+    public void queueServerFrame(int networkUniverse, byte[] dmxData) {
+        if (networkUniverse < 0 || dmxData == null) {
+            return;
+        }
+        int length = Math.min(dmxData.length, 512);
+        pendingServerFrames.put(networkUniverse, Arrays.copyOf(dmxData, length));
+    }
+
+    /** Envoie au serveur au plus une trame par univers et par tick client. */
+    public void flushPendingToServer() {
+        if (manager.getNetworkId() == UUIDUtil.NULL || pendingServerFrames.isEmpty()) {
+            return;
+        }
+        for (IntObjectMap.PrimitiveEntry<byte[]> entry : pendingServerFrames.int2ObjectEntrySet()) {
+            new SendArtNetData(manager.getNetworkId(), entry.intKey(), entry.value()).sendToServer();
+        }
+        pendingServerFrames.clear();
+    }
+
     private void onPacketReceived(InetAddress sourceAddress, final ArtNetPacket packet) {
         switch(packet.getType()){
             case ART_OUTPUT: {
@@ -184,7 +205,7 @@ public class TheatricalArtNetClient extends ArtNetClient {
                 getInputBuffer().setDmxData((short) subnet, (short) universe, dmxPacket.getDmxData());
                 int networkUniverse = getNetworkUniverse(subnet, universe);
                 if(networkUniverse != -1){
-                    new SendArtNetData(manager.getNetworkId(), networkUniverse, dmxPacket.getDmxData()).sendToServer();
+                    queueServerFrame(networkUniverse, dmxPacket.getDmxData());
                 }
                 break;
             }

--- a/common/src/main/java/dev/imabad/theatrical/client/dmx/TheatricalArtNetClient.java
+++ b/common/src/main/java/dev/imabad/theatrical/client/dmx/TheatricalArtNetClient.java
@@ -171,7 +171,7 @@ public class TheatricalArtNetClient extends ArtNetClient {
         return (int) (sum * (sum + 1) / 2) + a;
     }
 
-    private final IntObjectMap<byte[]> pendingServerFrames = new IntObjectHashMap<>();
+    private final Map<Integer, byte[]> pendingServerFrames = new HashMap<>();
 
     public void queueServerFrame(int networkUniverse, byte[] dmxData) {
         if (networkUniverse < 0 || dmxData == null) {
@@ -186,8 +186,8 @@ public class TheatricalArtNetClient extends ArtNetClient {
         if (manager.getNetworkId() == UUIDUtil.NULL || pendingServerFrames.isEmpty()) {
             return;
         }
-        for (IntObjectMap.Entry<byte[]> entry : pendingServerFrames.entries()) {
-            new SendArtNetData(manager.getNetworkId(), entry.key(), entry.value()).sendToServer();
+        for (Map.Entry<Integer, byte[]> entry : pendingServerFrames.entrySet()) {
+            new SendArtNetData(manager.getNetworkId(), entry.getKey(), entry.getValue()).sendToServer();
         }
         pendingServerFrames.clear();
     }

--- a/common/src/main/java/dev/imabad/theatrical/net/ConfigureConfigurationCard.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/ConfigureConfigurationCard.java
@@ -3,9 +3,14 @@ package dev.imabad.theatrical.net;
 import dev.architectury.networking.NetworkManager;
 import dev.architectury.networking.simple.BaseC2SMessage;
 import dev.architectury.networking.simple.MessageType;
+import dev.imabad.theatrical.Theatrical;
 import dev.imabad.theatrical.items.Items;
+import dev.imabad.theatrical.networks.TheatricalNetwork;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -57,13 +62,19 @@ public class ConfigureConfigurationCard extends BaseC2SMessage {
     @Override
     public void handle(NetworkManager.PacketContext context) {
         context.queue(() -> {
-            Player player = context.getPlayer();
-            ItemStack itemStack = null;
-            if(player.getItemInHand(InteractionHand.MAIN_HAND).getItem() == Items.CONFIGURATION_CARD.get()){
-                itemStack = player.getItemInHand(InteractionHand.MAIN_HAND);
-            } else if(player.getItemInHand(InteractionHand.OFF_HAND).getItem() == Items.CONFIGURATION_CARD.get()){
-                itemStack = player.getItemInHand(InteractionHand.OFF_HAND);
+            ServerPlayer player = (ServerPlayer) context.getPlayer();
+            TheatricalNetwork theatricalNetwork = DmxPacketGuard.resolveNetwork((ServerLevel) player.level(), network);
+            if (theatricalNetwork == null || !DmxPacketGuard.canConfigure(player, theatricalNetwork)) {
+                Theatrical.LOGGER.info("{} tried to configure a card for a network they cannot access", player.getName().getString());
+                return;
             }
+            if (addressEnabled && !DmxPacketGuard.isValidAddress(dmxAddress)) {
+                return;
+            }
+            if (universeEnabled && !DmxPacketGuard.isValidUniverse(dmxUniverse)) {
+                return;
+            }
+            ItemStack itemStack = findConfigurationCard(player);
             if(itemStack != null){
                 CompoundTag dataTag = itemStack.getOrCreateTag();
                 dataTag.putUUID("network", network);
@@ -75,5 +86,15 @@ public class ConfigureConfigurationCard extends BaseC2SMessage {
                 itemStack.save(dataTag);
             }
         });
+    }
+
+    private static ItemStack findConfigurationCard(Player player) {
+        if(player.getItemInHand(InteractionHand.MAIN_HAND).getItem() == Items.CONFIGURATION_CARD.get()){
+            return player.getItemInHand(InteractionHand.MAIN_HAND);
+        }
+        if(player.getItemInHand(InteractionHand.OFF_HAND).getItem() == Items.CONFIGURATION_CARD.get()){
+            return player.getItemInHand(InteractionHand.OFF_HAND);
+        }
+        return null;
     }
 }

--- a/common/src/main/java/dev/imabad/theatrical/net/ControlGo.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/ControlGo.java
@@ -4,8 +4,10 @@ import dev.architectury.networking.NetworkManager;
 import dev.architectury.networking.simple.BaseC2SMessage;
 import dev.architectury.networking.simple.MessageType;
 import dev.imabad.theatrical.blockentities.control.BasicLightingDeskBlockEntity;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 public class ControlGo extends BaseC2SMessage {
@@ -39,11 +41,15 @@ public class ControlGo extends BaseC2SMessage {
 
     @Override
     public void handle(NetworkManager.PacketContext context) {
-        BlockEntity be = context.getPlayer().level().getBlockEntity(blockPos);
+        ServerPlayer player = (ServerPlayer) context.getPlayer();
+        BlockEntity be = player.level().getBlockEntity(blockPos);
         if(be instanceof BasicLightingDeskBlockEntity lightingDeskBlock){
+            if (!DmxPacketGuard.canControlConsole(player, lightingDeskBlock)) {
+                return;
+            }
             if(!lightingDeskBlock.isRunMode()){
-                lightingDeskBlock.setFadeInTicks(fadeInTicks);
-                lightingDeskBlock.setFadeOutTicks(fadeOutTicks);
+                lightingDeskBlock.setFadeInTicks(DmxPacketGuard.clampNonNegative(fadeInTicks));
+                lightingDeskBlock.setFadeOutTicks(DmxPacketGuard.clampNonNegative(fadeOutTicks));
             }
             lightingDeskBlock.clickButton();
         }

--- a/common/src/main/java/dev/imabad/theatrical/net/ControlModeToggle.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/ControlModeToggle.java
@@ -4,8 +4,10 @@ import dev.architectury.networking.NetworkManager;
 import dev.architectury.networking.simple.BaseC2SMessage;
 import dev.architectury.networking.simple.MessageType;
 import dev.imabad.theatrical.blockentities.control.BasicLightingDeskBlockEntity;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 public class ControlModeToggle extends BaseC2SMessage {
@@ -32,8 +34,12 @@ public class ControlModeToggle extends BaseC2SMessage {
 
     @Override
     public void handle(NetworkManager.PacketContext context) {
-        BlockEntity be = context.getPlayer().level().getBlockEntity(blockPos);
+        ServerPlayer player = (ServerPlayer) context.getPlayer();
+        BlockEntity be = player.level().getBlockEntity(blockPos);
         if(be instanceof BasicLightingDeskBlockEntity lightingDeskBlock){
+            if (!DmxPacketGuard.canControlConsole(player, lightingDeskBlock)) {
+                return;
+            }
             lightingDeskBlock.toggleMode();
         }
     }

--- a/common/src/main/java/dev/imabad/theatrical/net/ControlMoveStep.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/ControlMoveStep.java
@@ -4,8 +4,10 @@ import dev.architectury.networking.NetworkManager;
 import dev.architectury.networking.simple.BaseC2SMessage;
 import dev.architectury.networking.simple.MessageType;
 import dev.imabad.theatrical.blockentities.control.BasicLightingDeskBlockEntity;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 public class ControlMoveStep extends BaseC2SMessage {
@@ -36,8 +38,12 @@ public class ControlMoveStep extends BaseC2SMessage {
 
     @Override
     public void handle(NetworkManager.PacketContext context) {
-        BlockEntity be = context.getPlayer().level().getBlockEntity(blockPos);
+        ServerPlayer player = (ServerPlayer) context.getPlayer();
+        BlockEntity be = player.level().getBlockEntity(blockPos);
         if(be instanceof BasicLightingDeskBlockEntity lightingDeskBlock){
+            if (!DmxPacketGuard.canControlConsole(player, lightingDeskBlock)) {
+                return;
+            }
             if(forward) {
                 lightingDeskBlock.moveForward();
             } else {

--- a/common/src/main/java/dev/imabad/theatrical/net/ControlUpdateFader.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/ControlUpdateFader.java
@@ -4,8 +4,10 @@ import dev.architectury.networking.NetworkManager;
 import dev.architectury.networking.simple.BaseC2SMessage;
 import dev.architectury.networking.simple.MessageType;
 import dev.imabad.theatrical.blockentities.control.BasicLightingDeskBlockEntity;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 public class ControlUpdateFader extends BaseC2SMessage {
@@ -40,8 +42,15 @@ public class ControlUpdateFader extends BaseC2SMessage {
 
     @Override
     public void handle(NetworkManager.PacketContext context) {
-        BlockEntity be = context.getPlayer().level().getBlockEntity(blockPos);
+        ServerPlayer player = (ServerPlayer) context.getPlayer();
+        if (!DmxPacketGuard.isValidFaderIndex(fader) || !DmxPacketGuard.isValidFaderValue(value)) {
+            return;
+        }
+        BlockEntity be = player.level().getBlockEntity(blockPos);
         if(be instanceof BasicLightingDeskBlockEntity lightingDeskBlock){
+            if (!DmxPacketGuard.canControlConsole(player, lightingDeskBlock)) {
+                return;
+            }
             lightingDeskBlock.setFader(fader, value);
         }
     }

--- a/common/src/main/java/dev/imabad/theatrical/net/UpdateDMXFixture.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/UpdateDMXFixture.java
@@ -3,10 +3,17 @@ package dev.imabad.theatrical.net;
 import dev.architectury.networking.NetworkManager;
 import dev.architectury.networking.simple.BaseC2SMessage;
 import dev.architectury.networking.simple.MessageType;
+import dev.imabad.theatrical.Theatrical;
+import dev.imabad.theatrical.api.dmx.BelongsToNetwork;
 import dev.imabad.theatrical.blockentities.interfaces.RedstoneInterfaceBlockEntity;
 import dev.imabad.theatrical.blockentities.light.BaseDMXConsumerLightBlockEntity;
+import dev.imabad.theatrical.networks.TheatricalNetwork;
+import dev.imabad.theatrical.util.DmxPacketGuard;
+import dev.imabad.theatrical.util.UUIDUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 public class UpdateDMXFixture extends BaseC2SMessage {
@@ -41,13 +48,46 @@ public class UpdateDMXFixture extends BaseC2SMessage {
 
     @Override
     public void handle(NetworkManager.PacketContext context) {
-        BlockEntity be = context.getPlayer().level().getBlockEntity(pos);
-        if(be instanceof BaseDMXConsumerLightBlockEntity dmxConsumerLightBlock){
+        ServerPlayer player = (ServerPlayer) context.getPlayer();
+        if (!DmxPacketGuard.canReach(player, pos)) {
+            return;
+        }
+        if (!DmxPacketGuard.isValidUniverse(dmxUniverse)) {
+            return;
+        }
+        BlockEntity be = player.level().getBlockEntity(pos);
+        if (be instanceof BaseDMXConsumerLightBlockEntity dmxConsumerLightBlock) {
+            if (!canConfigureFixture(player, dmxConsumerLightBlock.getNetworkId())) {
+                return;
+            }
+            if (!DmxPacketGuard.isValidAddress(dmxAddress)
+                    || !DmxPacketGuard.fitsInUniverse(dmxAddress, dmxConsumerLightBlock.getChannelCount())) {
+                return;
+            }
             dmxConsumerLightBlock.setChannelStartPoint(dmxAddress);
             dmxConsumerLightBlock.setUniverse(dmxUniverse);
-        } else if(be instanceof RedstoneInterfaceBlockEntity redstoneInterfaceBlockEntity){
+        } else if (be instanceof RedstoneInterfaceBlockEntity redstoneInterfaceBlockEntity) {
+            if (!canConfigureFixture(player, redstoneInterfaceBlockEntity.getNetworkId())) {
+                return;
+            }
+            if (!DmxPacketGuard.isValidAddress(dmxAddress)
+                    || !DmxPacketGuard.fitsInUniverse(dmxAddress, redstoneInterfaceBlockEntity.getChannelCount())) {
+                return;
+            }
             redstoneInterfaceBlockEntity.setChannelStartPoint(dmxAddress);
             redstoneInterfaceBlockEntity.setUniverse(dmxUniverse);
         }
+    }
+
+    private static boolean canConfigureFixture(ServerPlayer player, java.util.UUID networkId) {
+        if (networkId.equals(UUIDUtil.NULL)) {
+            return true;
+        }
+        TheatricalNetwork network = DmxPacketGuard.resolveNetwork((ServerLevel) player.level(), networkId);
+        if (network == null || !DmxPacketGuard.canConfigure(player, network)) {
+            Theatrical.LOGGER.info("{} tried to configure a fixture on a network they cannot access", player.getName().getString());
+            return false;
+        }
+        return true;
     }
 }

--- a/common/src/main/java/dev/imabad/theatrical/net/UpdateFixturePosition.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/UpdateFixturePosition.java
@@ -3,9 +3,16 @@ package dev.imabad.theatrical.net;
 import dev.architectury.networking.NetworkManager;
 import dev.architectury.networking.simple.BaseC2SMessage;
 import dev.architectury.networking.simple.MessageType;
+import dev.imabad.theatrical.Theatrical;
+import dev.imabad.theatrical.blockentities.light.BaseDMXConsumerLightBlockEntity;
 import dev.imabad.theatrical.blockentities.light.BaseLightBlockEntity;
+import dev.imabad.theatrical.networks.TheatricalNetwork;
+import dev.imabad.theatrical.util.DmxPacketGuard;
+import dev.imabad.theatrical.util.UUIDUtil;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 public class UpdateFixturePosition extends BaseC2SMessage {
@@ -40,10 +47,31 @@ public class UpdateFixturePosition extends BaseC2SMessage {
 
     @Override
     public void handle(NetworkManager.PacketContext context) {
-        BlockEntity be = context.getPlayer().level().getBlockEntity(pos);
-        if(be instanceof BaseLightBlockEntity baseLightBlockEntity){
-            baseLightBlockEntity.setPan(pan);
-            baseLightBlockEntity.setTilt(tilt);
+        ServerPlayer player = (ServerPlayer) context.getPlayer();
+        if (!DmxPacketGuard.canReach(player, pos)) {
+            return;
         }
+        BlockEntity be = player.level().getBlockEntity(pos);
+        if(be instanceof BaseLightBlockEntity baseLightBlockEntity){
+            if (be instanceof BaseDMXConsumerLightBlockEntity dmxConsumer) {
+                if (!canConfigureFixture(player, dmxConsumer.getNetworkId())) {
+                    return;
+                }
+            }
+            baseLightBlockEntity.setPan(DmxPacketGuard.clampPanTilt(pan));
+            baseLightBlockEntity.setTilt(DmxPacketGuard.clampPanTilt(tilt));
+        }
+    }
+
+    private static boolean canConfigureFixture(ServerPlayer player, java.util.UUID networkId) {
+        if (networkId.equals(UUIDUtil.NULL)) {
+            return true;
+        }
+        TheatricalNetwork network = DmxPacketGuard.resolveNetwork((ServerLevel) player.level(), networkId);
+        if (network == null || !DmxPacketGuard.canConfigure(player, network)) {
+            Theatrical.LOGGER.info("{} tried to move a fixture on a network they cannot access", player.getName().getString());
+            return false;
+        }
+        return true;
     }
 }

--- a/common/src/main/java/dev/imabad/theatrical/net/UpdateNetworkId.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/UpdateNetworkId.java
@@ -3,9 +3,14 @@ package dev.imabad.theatrical.net;
 import dev.architectury.networking.NetworkManager;
 import dev.architectury.networking.simple.BaseC2SMessage;
 import dev.architectury.networking.simple.MessageType;
+import dev.imabad.theatrical.Theatrical;
 import dev.imabad.theatrical.api.dmx.BelongsToNetwork;
+import dev.imabad.theatrical.networks.TheatricalNetwork;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 import java.util.UUID;
@@ -38,7 +43,16 @@ public class UpdateNetworkId extends BaseC2SMessage {
 
     @Override
     public void handle(NetworkManager.PacketContext context) {
-        BlockEntity be = context.getPlayer().level().getBlockEntity(blockPos);
+        ServerPlayer player = (ServerPlayer) context.getPlayer();
+        if (!DmxPacketGuard.canReach(player, blockPos)) {
+            return;
+        }
+        TheatricalNetwork network = DmxPacketGuard.resolveNetwork((ServerLevel) player.level(), networkId);
+        if (network == null || !DmxPacketGuard.canConfigure(player, network)) {
+            Theatrical.LOGGER.info("{} tried to assign a block to a network they cannot access", player.getName().getString());
+            return;
+        }
+        BlockEntity be = player.level().getBlockEntity(blockPos);
         if(be instanceof BelongsToNetwork belongsToNetwork){
             belongsToNetwork.setNetworkId(networkId);
         }

--- a/common/src/main/java/dev/imabad/theatrical/net/artnet/RDMUpdateConsumer.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/artnet/RDMUpdateConsumer.java
@@ -10,6 +10,7 @@ import dev.imabad.theatrical.blockentities.light.BaseDMXConsumerLightBlockEntity
 import dev.imabad.theatrical.networks.TheatricalNetwork;
 import dev.imabad.theatrical.networks.TheatricalNetworkData;
 import dev.imabad.theatrical.net.TheatricalNet;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.Level;
@@ -54,20 +55,27 @@ public class RDMUpdateConsumer extends BaseC2SMessage {
     @Override
     public void handle(NetworkManager.PacketContext context) {
         Level level = context.getPlayer().level();
-        if(level.getServer() != null ) {
-            TheatricalNetwork network = TheatricalNetworkData.getInstance(level.getServer().overworld()).getNetwork(networkId);
-            if(network == null || !network.members().canSendDMX(context.getPlayer().getUUID())) {
-                Theatrical.LOGGER.info("{} tried to send an RDM update for a network that doesn't exist or isn't part of", context.getPlayer().getName().getString());
-                return;
-            }
-            BlockPos consumerPos = network.dmx().getConsumerPos(universe, dmxDevice);
-            if(consumerPos != null){
-                BlockEntity be = context.getPlayer().level().getBlockEntity(consumerPos);
-                if(be instanceof BaseDMXConsumerLightBlockEntity dmxConsumerLightBlock){
-                    dmxConsumerLightBlock.setChannelStartPoint(newAddress);
-                } else if(be instanceof RedstoneInterfaceBlockEntity redstoneInterfaceBlockEntity){
-                    redstoneInterfaceBlockEntity.setChannelStartPoint(newAddress);
+        if(level.getServer() == null || !DmxPacketGuard.isValidUniverse(universe) || !DmxPacketGuard.isValidAddress(newAddress)) {
+            return;
+        }
+        TheatricalNetwork network = TheatricalNetworkData.getInstance(level.getServer().overworld()).getNetwork(networkId);
+        if(network == null || !network.members().canSendDMX(context.getPlayer().getUUID())) {
+            Theatrical.LOGGER.info("{} tried to send an RDM update for a network that doesn't exist or isn't part of", context.getPlayer().getName().getString());
+            return;
+        }
+        BlockPos consumerPos = network.dmx().getConsumerPos(universe, dmxDevice);
+        if(consumerPos != null){
+            BlockEntity be = context.getPlayer().level().getBlockEntity(consumerPos);
+            if(be instanceof BaseDMXConsumerLightBlockEntity dmxConsumerLightBlock){
+                if (!DmxPacketGuard.fitsInUniverse(newAddress, dmxConsumerLightBlock.getChannelCount())) {
+                    return;
                 }
+                dmxConsumerLightBlock.setChannelStartPoint(newAddress);
+            } else if(be instanceof RedstoneInterfaceBlockEntity redstoneInterfaceBlockEntity){
+                if (!DmxPacketGuard.fitsInUniverse(newAddress, redstoneInterfaceBlockEntity.getChannelCount())) {
+                    return;
+                }
+                redstoneInterfaceBlockEntity.setChannelStartPoint(newAddress);
             }
         }
     }

--- a/common/src/main/java/dev/imabad/theatrical/net/artnet/RequestConsumers.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/artnet/RequestConsumers.java
@@ -49,7 +49,7 @@ public class RequestConsumers extends BaseC2SMessage {
         Level level = context.getPlayer().level();
         if(level.getServer() != null ) {
             TheatricalNetwork network = TheatricalNetworkData.getInstance(level.getServer().overworld()).getNetwork(networkId);
-            if(network != null && network.members().isMember(context.getPlayer().getUUID())){
+            if(network != null && network.members().canSendDMX(context.getPlayer().getUUID())){
                 List<DMXDevice> devices = new ArrayList<>();
                 Collection<DMXConsumer> consumers = network.dmx().getConsumers(universe);
                 if(consumers == null){

--- a/common/src/main/java/dev/imabad/theatrical/net/artnet/SendArtNetData.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/artnet/SendArtNetData.java
@@ -8,6 +8,7 @@ import dev.imabad.theatrical.api.dmx.DMXConsumer;
 import dev.imabad.theatrical.networks.TheatricalNetwork;
 import dev.imabad.theatrical.networks.TheatricalNetworkData;
 import dev.imabad.theatrical.net.TheatricalNet;
+import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.Level;
 
@@ -47,23 +48,23 @@ public class SendArtNetData extends BaseC2SMessage {
     @Override
     public void handle(NetworkManager.PacketContext context) {
         Level level = context.getPlayer().level();
-        if(level.getServer() != null) {
-            TheatricalNetwork network = TheatricalNetworkData.getInstance(level.getServer().overworld()).getNetwork(networkId);
-            UUID uuid = context.getPlayer().getUUID();
-            if(network != null) {
-                if (network.members().isMember(uuid) && network.members().canSendDMX(uuid)) {
-                    Collection<DMXConsumer> consumers = network.dmx().getConsumers(universe);
-                    if(consumers != null) {
-                        consumers.forEach(consumer -> {
-                            consumer.consume(artNetData);
-                        });
-                    }
-                } else {
-                    Theatrical.LOGGER.info("{} tried to send ArtNet data to a network ({}) that they don't have permissions for", context.getPlayer().getName().getString(), network.name());
+        if(level.getServer() == null || !DmxPacketGuard.isValidUniverse(universe)) {
+            return;
+        }
+        TheatricalNetwork network = TheatricalNetworkData.getInstance(level.getServer().overworld()).getNetwork(networkId);
+        UUID uuid = context.getPlayer().getUUID();
+        if(network != null) {
+            if (network.members().isMember(uuid) && network.members().canSendDMX(uuid)) {
+                Collection<DMXConsumer> consumers = network.dmx().getConsumers(universe);
+                if(consumers != null) {
+                    byte[] normalized = DmxPacketGuard.normalizeDmxBuffer(artNetData);
+                    consumers.forEach(consumer -> consumer.consume(normalized));
                 }
             } else {
-                Theatrical.LOGGER.info("{} tried to send ArtNet data to a network that doesn't exist.", context.getPlayer().getName().getString());
+                Theatrical.LOGGER.info("{} tried to send ArtNet data to a network ({}) that they don't have permissions for", context.getPlayer().getName().getString(), network.name());
             }
+        } else {
+            Theatrical.LOGGER.info("{} tried to send ArtNet data to a network that doesn't exist.", context.getPlayer().getName().getString());
         }
     }
 }

--- a/common/src/main/java/dev/imabad/theatrical/net/artnet/SendArtNetData.java
+++ b/common/src/main/java/dev/imabad/theatrical/net/artnet/SendArtNetData.java
@@ -4,7 +4,7 @@ import dev.architectury.networking.NetworkManager;
 import dev.architectury.networking.simple.BaseC2SMessage;
 import dev.architectury.networking.simple.MessageType;
 import dev.imabad.theatrical.Theatrical;
-import dev.imabad.theatrical.api.dmx.DMXConsumer;
+import dev.imabad.theatrical.networks.ServerDmxBroker;
 import dev.imabad.theatrical.networks.TheatricalNetwork;
 import dev.imabad.theatrical.networks.TheatricalNetworkData;
 import dev.imabad.theatrical.net.TheatricalNet;
@@ -12,7 +12,6 @@ import dev.imabad.theatrical.util.DmxPacketGuard;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.level.Level;
 
-import java.util.Collection;
 import java.util.UUID;
 
 public class SendArtNetData extends BaseC2SMessage {
@@ -55,11 +54,7 @@ public class SendArtNetData extends BaseC2SMessage {
         UUID uuid = context.getPlayer().getUUID();
         if(network != null) {
             if (network.members().isMember(uuid) && network.members().canSendDMX(uuid)) {
-                Collection<DMXConsumer> consumers = network.dmx().getConsumers(universe);
-                if(consumers != null) {
-                    byte[] normalized = DmxPacketGuard.normalizeDmxBuffer(artNetData);
-                    consumers.forEach(consumer -> consumer.consume(normalized));
-                }
+                ServerDmxBroker.queue(networkId, universe, artNetData);
             } else {
                 Theatrical.LOGGER.info("{} tried to send ArtNet data to a network ({}) that they don't have permissions for", context.getPlayer().getName().getString(), network.name());
             }

--- a/common/src/main/java/dev/imabad/theatrical/networks/NetworkDMXManager.java
+++ b/common/src/main/java/dev/imabad/theatrical/networks/NetworkDMXManager.java
@@ -80,7 +80,7 @@ public class NetworkDMXManager {
             return consumers;
         }
         for(Map.Entry<BlockPos, DMXConsumer> entry : dmxUniverseToNodeMap.get(universe).entrySet()){
-            if(Math.sqrt(fromPos.distToCenterSqr(entry.getKey().getX(), entry.getKey().getY(), entry.getKey().getZ())) <= radius){
+            if(fromPos.distSqr(entry.getKey()) <= (long) radius * radius){
                 consumers.add(entry.getValue());
             }
         }

--- a/common/src/main/java/dev/imabad/theatrical/networks/NetworkDMXManager.java
+++ b/common/src/main/java/dev/imabad/theatrical/networks/NetworkDMXManager.java
@@ -62,7 +62,11 @@ public class NetworkDMXManager {
     }
 
     public BlockPos getConsumerPos(int universe, RDMDeviceId deviceId){
-        for (Map.Entry<BlockPos, DMXConsumer> blockPosDMXConsumerEntry : dmxUniverseToNodeMap.get(universe).entrySet()) {
+        Map<BlockPos, DMXConsumer> universeConsumers = dmxUniverseToNodeMap.get(universe);
+        if (universeConsumers == null) {
+            return null;
+        }
+        for (Map.Entry<BlockPos, DMXConsumer> blockPosDMXConsumerEntry : universeConsumers.entrySet()) {
             if(blockPosDMXConsumerEntry.getValue().getDeviceId().equals(deviceId)){
                 return blockPosDMXConsumerEntry.getKey();
             }

--- a/common/src/main/java/dev/imabad/theatrical/networks/ServerDmxBroker.java
+++ b/common/src/main/java/dev/imabad/theatrical/networks/ServerDmxBroker.java
@@ -1,0 +1,70 @@
+package dev.imabad.theatrical.networks;
+
+import dev.imabad.theatrical.api.dmx.DMXConsumer;
+import dev.imabad.theatrical.util.DmxPacketGuard;
+import net.minecraft.server.MinecraftServer;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Coalesces incoming Art-Net / DMX frames to one apply pass per server tick per universe.
+ * Prevents main-thread stalls when clients relay ~40 Hz Art-Net packets.
+ */
+public final class ServerDmxBroker {
+
+    private record UniverseKey(UUID networkId, int universe) {}
+
+    private static final Map<UniverseKey, byte[]> pending = new HashMap<>();
+    private static final Map<UniverseKey, byte[]> lastApplied = new HashMap<>();
+
+    private ServerDmxBroker() {
+    }
+
+    public static void queue(UUID networkId, int universe, byte[] data) {
+        if (data == null || data.length == 0) {
+            return;
+        }
+        int length = Math.min(data.length, DmxPacketGuard.DMX_CHANNELS_PER_UNIVERSE);
+        pending.put(new UniverseKey(networkId, universe), Arrays.copyOf(data, length));
+    }
+
+    public static void flush(MinecraftServer server) {
+        if (pending.isEmpty() || server == null) {
+            return;
+        }
+        Map<UniverseKey, byte[]> snapshot = new HashMap<>(pending);
+        pending.clear();
+
+        TheatricalNetworkData networkData = TheatricalNetworkData.getInstance(server.overworld());
+        for (Map.Entry<UniverseKey, byte[]> entry : snapshot.entrySet()) {
+            UniverseKey key = entry.getKey();
+            TheatricalNetwork network = networkData.getNetwork(key.networkId());
+            if (network == null) {
+                continue;
+            }
+            byte[] normalized = DmxPacketGuard.normalizeDmxBuffer(entry.getValue());
+            byte[] previous = lastApplied.get(key);
+            if (previous != null && Arrays.equals(previous, normalized)) {
+                continue;
+            }
+            lastApplied.put(key, normalized);
+
+            Collection<DMXConsumer> consumers = network.dmx().getConsumers(key.universe());
+            if (consumers == null || consumers.isEmpty()) {
+                continue;
+            }
+            for (DMXConsumer consumer : consumers) {
+                consumer.consume(normalized);
+            }
+        }
+    }
+
+    public static void clearNetwork(UUID networkId) {
+        pending.keySet().removeIf(key -> key.networkId().equals(networkId));
+        lastApplied.keySet().removeIf(key -> key.networkId().equals(networkId));
+    }
+}

--- a/common/src/main/java/dev/imabad/theatrical/util/DmxPacketGuard.java
+++ b/common/src/main/java/dev/imabad/theatrical/util/DmxPacketGuard.java
@@ -1,0 +1,105 @@
+package dev.imabad.theatrical.util;
+
+import dev.imabad.theatrical.blockentities.control.BasicLightingDeskBlockEntity;
+import dev.imabad.theatrical.config.TheatricalConfig;
+import dev.imabad.theatrical.networks.TheatricalNetwork;
+import dev.imabad.theatrical.networks.TheatricalNetworkData;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+public final class DmxPacketGuard {
+
+    public static final int DMX_CHANNELS_PER_UNIVERSE = 512;
+    private static final int CONSOLE_FADER_COUNT = 12;
+
+    private DmxPacketGuard() {
+    }
+
+    public static boolean isValidAddress(int address) {
+        return address >= 1 && address <= DMX_CHANNELS_PER_UNIVERSE;
+    }
+
+    public static boolean isValidUniverse(int universe) {
+        return universe >= 0;
+    }
+
+    public static boolean fitsInUniverse(int address, int footprint) {
+        return isValidAddress(address) && address + footprint - 1 <= DMX_CHANNELS_PER_UNIVERSE;
+    }
+
+    public static boolean canReach(ServerPlayer player, BlockPos pos) {
+        double radius = TheatricalConfig.INSTANCE.COMMON.wirelessDMXRadius;
+        return player.distanceToSqr(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5) <= radius * radius;
+    }
+
+    public static boolean canConfigure(ServerPlayer player, TheatricalNetwork network) {
+        return network.members().isMember(player.getUUID());
+    }
+
+    public static boolean canSendDmx(ServerPlayer player, TheatricalNetwork network) {
+        return network.members().canSendDMX(player.getUUID());
+    }
+
+    @Nullable
+    public static TheatricalNetwork resolveNetwork(ServerLevel level, UUID networkId) {
+        if (level.getServer() == null) {
+            return null;
+        }
+        return TheatricalNetworkData.getInstance(level.getServer().overworld()).getNetwork(networkId);
+    }
+
+    public static byte[] normalizeDmxBuffer(byte[] data) {
+        if (data == null) {
+            return new byte[0];
+        }
+        if (data.length <= DMX_CHANNELS_PER_UNIVERSE) {
+            return data;
+        }
+        return Arrays.copyOf(data, DMX_CHANNELS_PER_UNIVERSE);
+    }
+
+    public static byte[] sliceDmxChannels(byte[] dmxValues, int channelStart, int channelCount) {
+        if (dmxValues == null || channelCount <= 0) {
+            return new byte[0];
+        }
+        int start = channelStart > 0 ? channelStart - 1 : 0;
+        if (start >= dmxValues.length) {
+            return new byte[0];
+        }
+        int end = Math.min(start + channelCount, dmxValues.length);
+        return Arrays.copyOfRange(dmxValues, start, end);
+    }
+
+    public static boolean canControlConsole(ServerPlayer player, BasicLightingDeskBlockEntity desk) {
+        if (!canReach(player, desk.getBlockPos())) {
+            return false;
+        }
+        UUID networkId = desk.getNetworkId();
+        if (networkId.equals(UUIDUtil.NULL)) {
+            return true;
+        }
+        TheatricalNetwork network = resolveNetwork((ServerLevel) player.level(), networkId);
+        return network != null && canSendDmx(player, network);
+    }
+
+    public static boolean isValidFaderIndex(int fader) {
+        return fader >= 0 && fader < CONSOLE_FADER_COUNT;
+    }
+
+    public static boolean isValidFaderValue(int value) {
+        return value >= 0 && value <= 255;
+    }
+
+    public static int clampPanTilt(int value) {
+        return Math.max(-360, Math.min(360, value));
+    }
+
+    public static int clampNonNegative(int value) {
+        return Math.max(0, value);
+    }
+}


### PR DESCRIPTION
## Summary

Hardens the DMX networking surface for multiplayer, fixes Art-Net performance stalls on busy rigs, and improves client-side fixture interpolation — without changing normal show operation for authorized members.

This PR bundles five related commits:

| Area | What changes |
|------|----------------|
| **Security** | Centralized `DmxPacketGuard` + validation on all vulnerable C2S handlers |
| **Performance** | `ServerDmxBroker` coalesces Art-Net/DMX to one apply pass per tick per universe |
| **Stability** | Thread-safe Art-Net client queue, Forge-safe pending-frame storage, NPE fixes |
| **Rendering** | Client `lightTick()` advances `prev*` values for smoother pan/tilt/intensity |

---

## Security

Several client-to-server packets could previously modify fixtures, network assignments, or the basic lighting console **without** membership checks, reach checks, or DMX bounds validation.

**New: `DmxPacketGuard`** — shared helpers for:
- Reach distance (`wirelessDMXRadius`)
- Network membership / `canSendDMX` permissions
- DMX address (1–512) and universe validation
- Safe buffer slicing (`sliceDmxChannels`, `normalizeDmxBuffer`)
- Basic lighting console control (fader index, role, range)

**Protected C2S handlers:**
- `UpdateDMXFixture`, `UpdateNetworkId`, `UpdateFixturePosition`
- `ControlUpdateFader`, `ControlMoveStep`, `ControlModeToggle`, `ControlGo`
- `ConfigureConfigurationCard`

**Art-Net hardening:**
- `SendArtNetData` — normalize buffers to 512 bytes, permission check unchanged but aligned
- `RDMUpdateConsumer` — validated address updates
- `RequestConsumers` — requires `canSendDMX`

**Defense in depth on block entities:**
- Reject invalid address/universe in `setChannelStartPoint` / `setUniverse`
- Replace unsafe `Arrays.copyOfRange` in all `consume()` paths with bounded slicing (no crash on truncated packets)

**Crash fixes:**
- NPE in `NetworkDMXManager.getConsumerPos`
- Player join consumer sync when DMX universes are empty

---

## Performance (Art-Net coalescing)

Art-Net packets were applied on every C2S frame (~40 Hz), flooding the main thread with `consume()` calls and redundant block syncs.

**`ServerDmxBroker`** (server):
- Queues incoming frames per `(networkId, universe)`
- Flushes once per server tick
- Skips identical consecutive frames (dedup)
- Applies normalized 512-byte buffers to consumers

**`TheatricalArtNetClient`** (client):
- Batches outgoing Art-Net relay to one send per client tick (`flushPendingToServer`)

**Fixture sync:**
- Single `sendBlockUpdated` per DMX frame instead of double prev/values sync
- Server raytrace skipped during batched consume where safe

---

## Client animation & thread safety

- **`lightTick()`** on client now advances `prevPan`, `prevTilt`, `prevIntensity`, etc. so renderers can interpolate smoothly between DMX frames
- **Synchronized** access to `pendingServerFrames` in `TheatricalArtNetClient` to prevent races when multiple threads touch the queue

---

## Platform fixes

- **Forge:** `HashMap` instead of `IntObjectHashMap` for pending Art-Net frames (compatibility)
- **Art-Net flush:** use `IntObjectMap` entries API correctly during coalesced flush

---

## Motivation

| Problem | Before | After |
|---------|--------|-------|
| Malicious client repatches remote fixtures | Possible | Rejected server-side |
| Console driven out of range / without role | Possible | Rejected |
| 40 Hz Art-Net on large rig | Main-thread stalls | One apply/tick/universe |
| Pan/tilt jitter on client | `prev*` not advanced every tick | Smooth interpolation |
| Truncated DMX buffer | Server crash (`copyOfRange`) | Safe empty slice |

`SendArtNetData` already had partial checks; this PR aligns the **entire DMX packet surface** with the same trust model.

---

## Out of scope

- Art-Net discovery (`ArtPollReply` / `numPorts`)
- RDM universe mapping improvements
- Dead Art-Net Interface block cleanup

Planned as follow-up PRs.

---

## Test plan

### Security
- [x] Non-member sends `UpdateDMXFixture` → rejected (server log)
- [x] Member beyond `wirelessDMXRadius` → rejected
- [x] Invalid DMX address (0 or 513) → rejected server-side
- [x] Console fader index 99 → rejected; indices 0–11 work for SEND role in range
- [x] `SendArtNetData` with oversized buffer → truncated to 512, no crash
- [x] Player join with empty DMX universes → no NPE

### Performance
- [x] Art-Net relay at ~40 Hz on 300+ fixture rig → no visible server freeze
- [x] Identical consecutive frames → deduped (no redundant consume)

### Rendering
- [x] Moving heads pan/tilt smoothly between DMX frames on client
- [x] Normal show operation unchanged for authorized members in range

### Platforms
- [x] Fabric — Art-Net coalescing works
- [x] Forge — pending frames queue without `IntObjectHashMap` issues